### PR TITLE
fix(devspace): prevent e2e pipeline hang after test completion

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,9 +3,6 @@ version: v2beta1
 vars:
   CHAT_NAMESPACE: platform
 
-commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
 functions:
   disable_argocd_sync: |-
     if kubectl get application chat -n argocd >/dev/null 2>&1; then
@@ -152,10 +149,10 @@ pipelines:
       restore_argocd_sync
       trap - EXIT
 
-  test:e2e:
+  e2e:
     run: |-
       create_deployments chat-e2e
-      trap 'purge_deployments chat-e2e' EXIT
+      trap 'stop_dev chat-e2e; purge_deployments chat-e2e' EXIT
       start_dev chat-e2e --disable-pod-replace
       echo "Waiting for source files to sync..."
       sleep 5
@@ -166,6 +163,7 @@ pipelines:
       exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=chat-e2e -n ${CHAT_NAMESPACE} -- \
         bash -c 'cd /opt/app/data && go test -v -count=1 ./test/e2e/...'
       echo "Cleaning up test runner pod..."
+      stop_dev chat-e2e
       purge_deployments chat-e2e
       trap - EXIT
 
@@ -212,6 +210,7 @@ dev:
       app.kubernetes.io/component: chat-e2e
     sync:
       - path: ./:/opt/app/data
+        noWatch: true
         excludePaths:
           - .git/
           - /gen/


### PR DESCRIPTION
## Summary

Fixes the e2e DevSpace pipeline hanging after tests complete. After `purge_deployments` deletes the test runner pod, the background `start_dev` sync process would try to reconnect indefinitely.

## Changes

- **`noWatch: true`** on `dev.chat-e2e.sync` — sync uploads once and exits, no background file watcher
- **`stop_dev chat-e2e`** before `purge_deployments` — cleanly tears down dev mode session
- **Trap updated** to include `stop_dev` for cleanup on failure
- **Pipeline renamed** from `test:e2e` to `e2e` (colons not allowed in DevSpace pipeline names)
- **Removed orphaned `commands` section** that referenced the old name

## Testing

- `devspace print` validates successfully
- All 22 e2e tests pass against live bootstrap cluster (verified in prior run)
- Casey confirmed pipeline exits cleanly with these changes applied locally

Refs #5