### PR TITLE
Add multi-arch manifest verification to docker workflow

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -65,10 +65,15 @@ jobs:
         run: |
           TAG="${GITHUB_REF_NAME#v}"
           INSPECT="$(docker buildx imagetools inspect "$IMAGE_NAME:$TAG" --raw)"
+          FOUND="$(echo "$INSPECT" | jq -r '[.manifests[].platform.architecture] | sort | join(",")')"
+          MISSING=()
           for ARCH in amd64 arm64; do
-            if ! echo "$INSPECT" | grep -q "\"architecture\":\"$ARCH\"\|\"architecture\": \"$ARCH\""; then
-              echo "::error::linux/$ARCH missing from manifest $IMAGE_NAME:$TAG"
-              exit 1
+            if ! echo "$FOUND" | grep -q "$ARCH"; then
+              MISSING+=("linux/$ARCH")
             fi
           done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::Missing architectures in $IMAGE_NAME:$TAG: ${MISSING[*]}"
+            exit 1
+          fi
           echo "Manifest $IMAGE_NAME:$TAG includes linux/amd64 and linux/arm64"


### PR DESCRIPTION
Adds a verification step after the image build-and-push in the `docker-ghcr.yml` workflow, per the updated [Multi-Architecture Image Requirements](https://github.com/agynio/architecture/blob/main/architecture/operations/ci-cd.md#multi-architecture-image-requirements).

### Change

New "Verify multi-arch manifest" step in the `build` job that:
1. Derives the semver tag from `GITHUB_REF_NAME`
2. Runs `docker buildx imagetools inspect --raw` against the pushed image
3. Asserts both `linux/amd64` and `linux/arm64` architectures are present
4. Fails the job with a GitHub Actions error annotation if either is missing

Closes #14