### PR TITLE
Remove tenant metadata from identity

### DIFF
--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -10,13 +10,11 @@ import (
 const (
 	MetadataKeyIdentityID   = "x-identity-id"
 	MetadataKeyIdentityType = "x-identity-type"
-	MetadataKeyTenantID     = "x-tenant-id"
 )
 
 type Identity struct {
 	IdentityID   string
 	IdentityType string
-	TenantID     string
 }
 
 func FromContext(ctx context.Context) (Identity, error) {
@@ -35,15 +33,9 @@ func FromContext(ctx context.Context) (Identity, error) {
 		return Identity{}, err
 	}
 
-	tenantID, err := singleValue(md, MetadataKeyTenantID)
-	if err != nil {
-		return Identity{}, err
-	}
-
 	return Identity{
 		IdentityID:   identityID,
 		IdentityType: identityType,
-		TenantID:     tenantID,
 	}, nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -91,7 +91,6 @@ func contextWithIdentity(identityID string) context.Context {
 	md := metadata.New(map[string]string{
 		identity.MetadataKeyIdentityID:   identityID,
 		identity.MetadataKeyIdentityType: "user",
-		identity.MetadataKeyTenantID:     "tenant-1",
 	})
 	return metadata.NewIncomingContext(context.Background(), md)
 }
@@ -289,7 +288,7 @@ func TestSendMessageDelegates(t *testing.T) {
 func TestMarkAsReadValidation(t *testing.T) {
 	ctx := contextWithIdentity("user-1")
 	for name, req := range map[string]*chatv1.MarkAsReadRequest{
-		"missing chat id":   {MessageIds: []string{"msg-1"}},
+		"missing chat id":     {MessageIds: []string{"msg-1"}},
 		"missing message ids": {ChatId: "chat-1"},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -143,8 +143,7 @@ func TestGetMessages_UnreadCount(t *testing.T) {
 	env := setupEnv(t)
 	_, readerCtx := testIdentity()
 	otherID := uniqueID()
-	tenantID := uniqueID()
-	senderCtx := ctxWithIdentity(otherID, "user", tenantID)
+	senderCtx := ctxWithIdentity(otherID, "user")
 
 	chat := createChat(t, env, readerCtx, otherID)
 
@@ -244,8 +243,7 @@ func TestMarkAsRead(t *testing.T) {
 	env := setupEnv(t)
 	_, readerCtx := testIdentity()
 	otherID := uniqueID()
-	tenantID := uniqueID()
-	senderCtx := ctxWithIdentity(otherID, "user", tenantID)
+	senderCtx := ctxWithIdentity(otherID, "user")
 
 	chat := createChat(t, env, readerCtx, otherID)
 
@@ -268,8 +266,7 @@ func TestMarkAsRead_Idempotent(t *testing.T) {
 	env := setupEnv(t)
 	_, readerCtx := testIdentity()
 	otherID := uniqueID()
-	tenantID := uniqueID()
-	senderCtx := ctxWithIdentity(otherID, "user", tenantID)
+	senderCtx := ctxWithIdentity(otherID, "user")
 
 	chat := createChat(t, env, readerCtx, otherID)
 	msg := sendMessage(t, env, senderCtx, chat.GetId(), "msg")

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -53,14 +53,13 @@ func uniqueID() string {
 // testIdentity returns a unique identity ID and a context with identity metadata.
 func testIdentity() (string, context.Context) {
 	id := uniqueID()
-	return id, ctxWithIdentity(id, "user", uniqueID())
+	return id, ctxWithIdentity(id, "user")
 }
 
-func ctxWithIdentity(identityID, identityType, tenantID string) context.Context {
+func ctxWithIdentity(identityID, identityType string) context.Context {
 	md := metadata.Pairs(
 		"x-identity-id", identityID,
 		"x-identity-type", identityType,
-		"x-tenant-id", tenantID,
 	)
 	return metadata.NewOutgoingContext(context.Background(), md)
 }


### PR DESCRIPTION
## Summary
- remove tenant metadata from identity extraction
- update server and e2e test helpers to omit tenant headers

## Testing
- go vet ./...
- go build ./...
- CHAT_ADDRESS=127.0.0.1:50051 go test ./...

Refs #16