### PR TITLE
fix(chart): default threadsAddress to threads:50051

### DIFF
--- a/charts/chat/templates/_helpers.tpl
+++ b/charts/chat/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "chat.configureEnv" -}}
 {{- $env := list -}}
 
-{{- $threadsAddress := required "chat.threadsAddress must be set" .Values.chat.threadsAddress -}}
+{{- $threadsAddress := .Values.chat.threadsAddress -}}
 {{- $env = append $env (dict "name" "THREADS_ADDRESS" "value" $threadsAddress) -}}
 
 {{- $userEnv := .Values.env | default (list) -}}

--- a/charts/chat/values.yaml
+++ b/charts/chat/values.yaml
@@ -155,4 +155,4 @@ metrics:
 
 # -- Chat-specific configuration
 chat:
-  threadsAddress: ""
+  threadsAddress: "threads:50051"


### PR DESCRIPTION
## Problem

The chat Helm chart v0.2.0 uses `required` on `chat.threadsAddress`, which forces every deployment (bootstrap terraform, ArgoCD, etc.) to explicitly set this value. If omitted, Helm template rendering fails:

```
Error: execution error at (chat/templates/deployment.yaml:1:4): chat.threadsAddress must be set
```

This breaks `agynio/bootstrap` PR #156 which bumps the chat chart to v0.2.0.

## Convention

The gateway chart follows a convention where all inter-service gRPC targets default to their in-cluster Kubernetes DNS names:

```yaml
# gateway/charts/gateway/values.yaml
gateway:
  agentsGrpcTarget: "agents:50051"
  threadsGrpcTarget: "threads:50051"
  chatGrpcTarget: "chat:50051"
  # ...
```

Bootstrap only overrides values that are genuinely deployment-specific (OIDC config). It does **not** override inter-service addresses because the defaults are correct for the standard deployment topology.

## Fix

1. **`values.yaml`**: Change `chat.threadsAddress` default from `""` to `"threads:50051"`
2. **`_helpers.tpl`**: Remove the `required` check — the default is always valid

The `helm lint` step in `helm-release.yml` currently works around the `required` check with `--set chat.threadsAddress=threads:50051`. That override becomes unnecessary (but harmless) after this fix.

## Impact

- Unblocks `agynio/bootstrap#156` (chat v0.2.0 deployment)
- Aligns with the gateway chart convention
- No behavior change for deployments that already explicitly set `chat.threadsAddress`

Requires a new tag (v0.2.1) after merge, and bootstrap PR #156 should be updated to reference v0.2.1.