### PR TITLE
fix: use numeric UID in Dockerfile for runAsNonRoot compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,6 @@ LABEL org.opencontainers.image.source="https://github.com/agynio/chat"
 
 COPY --from=build /out/chat /usr/local/bin/chat
 
-USER nonroot:nonroot
+USER 65534:65534
 
 ENTRYPOINT ["/usr/local/bin/chat"]


### PR DESCRIPTION
Kubernetes `runAsNonRoot` security context requires a numeric UID to verify the container user is non-root. The string `nonroot` causes:

```
Error: container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root
```

The distroless base image's `nonroot` user maps to UID `65534`. Using the numeric form directly.