### PR TITLE
feat(chat): add chat status updates

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -1,11 +1,18 @@
 package server
 
 import (
+	"fmt"
+
 	chatv1 "github.com/agynio/chat/gen/go/agynio/api/chat/v1"
 	threadsv1 "github.com/agynio/chat/gen/go/agynio/api/threads/v1"
 )
 
-func threadToChat(thread *threadsv1.Thread, organizationID string) *chatv1.Chat {
+const (
+	chatStatusOpen   = "open"
+	chatStatusClosed = "closed"
+)
+
+func threadToChat(thread *threadsv1.Thread, organizationID string, status chatv1.ChatStatus, summary *string) *chatv1.Chat {
 	participants := make([]*chatv1.ChatParticipant, len(thread.GetParticipants()))
 	for i, p := range thread.GetParticipants() {
 		participants[i] = &chatv1.ChatParticipant{
@@ -20,6 +27,30 @@ func threadToChat(thread *threadsv1.Thread, organizationID string) *chatv1.Chat 
 		CreatedAt:      thread.GetCreatedAt(),
 		UpdatedAt:      thread.GetUpdatedAt(),
 		OrganizationId: organizationID,
+		Status:         status,
+		Summary:        summary,
+	}
+}
+
+func chatStatusToString(status chatv1.ChatStatus) string {
+	switch status {
+	case chatv1.ChatStatus_CHAT_STATUS_OPEN:
+		return chatStatusOpen
+	case chatv1.ChatStatus_CHAT_STATUS_CLOSED:
+		return chatStatusClosed
+	default:
+		panic(fmt.Sprintf("unsupported chat status: %s", status))
+	}
+}
+
+func stringToChatStatus(status string) chatv1.ChatStatus {
+	switch status {
+	case chatStatusOpen:
+		return chatv1.ChatStatus_CHAT_STATUS_OPEN
+	case chatStatusClosed:
+		return chatv1.ChatStatus_CHAT_STATUS_CLOSED
+	default:
+		panic(fmt.Sprintf("unsupported chat status: %s", status))
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,9 @@ const maxThreadsPages = 10
 
 type chatStore interface {
 	CreateChat(ctx context.Context, threadID, organizationID uuid.UUID) (store.Chat, error)
-	ListChats(ctx context.Context, organizationID uuid.UUID, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error)
+	GetChat(ctx context.Context, threadID uuid.UUID) (store.Chat, error)
+	UpdateChat(ctx context.Context, threadID uuid.UUID, params store.UpdateChatParams) (store.Chat, error)
+	ListChats(ctx context.Context, organizationID uuid.UUID, filter store.ChatListFilter, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error)
 }
 
 func New(threads threadsv1.ThreadsServiceClient, store chatStore) *Server {
@@ -72,12 +74,19 @@ func (s *Server) CreateChat(ctx context.Context, req *chatv1.CreateChatRequest) 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "threads returned invalid thread id: %v", err)
 	}
-	if _, err := s.store.CreateChat(ctx, threadID, organizationID); err != nil {
+	storedChat, err := s.store.CreateChat(ctx, threadID, organizationID)
+	if err != nil {
 		log.Printf("chat: store thread %s for org %s failed (returning thread only): %v", threadID, organizationID, err)
+	}
+	status := chatv1.ChatStatus_CHAT_STATUS_OPEN
+	var summary *string
+	if err == nil {
+		status = stringToChatStatus(storedChat.Status)
+		summary = storedChat.Summary
 	}
 
 	return &chatv1.CreateChatResponse{
-		Chat: threadToChat(resp.GetThread(), organizationID.String()),
+		Chat: threadToChat(resp.GetThread(), organizationID.String(), status, summary),
 	}, nil
 }
 
@@ -98,11 +107,16 @@ func (s *Server) GetChats(ctx context.Context, req *chatv1.GetChatsRequest) (*ch
 	}
 
 	pageSize := store.NormalizePageSize(req.GetPageSize())
+	filter := store.ChatListFilter{}
+	if req.GetStatus() != chatv1.ChatStatus_CHAT_STATUS_UNSPECIFIED {
+		statusValue := chatStatusToString(req.GetStatus())
+		filter.Status = &statusValue
+	}
 	chats := make([]*chatv1.Chat, 0, int(pageSize))
 	var nextCursor *store.PageCursor
 	for len(chats) < int(pageSize) {
 		remaining := pageSize - int32(len(chats))
-		result, err := s.store.ListChats(ctx, organizationID, remaining, cursor)
+		result, err := s.store.ListChats(ctx, organizationID, filter, remaining, cursor)
 		if err != nil {
 			return nil, toStatusError(err)
 		}
@@ -129,7 +143,7 @@ func (s *Server) GetChats(ctx context.Context, req *chatv1.GetChatsRequest) (*ch
 			if !threadHasParticipant(thread, id.IdentityID) {
 				continue
 			}
-			chats = append(chats, threadToChat(thread, chat.OrganizationID.String()))
+			chats = append(chats, threadToChat(thread, chat.OrganizationID.String(), stringToChatStatus(chat.Status), chat.Summary))
 		}
 
 		nextCursor = result.NextCursor
@@ -147,6 +161,53 @@ func (s *Server) GetChats(ctx context.Context, req *chatv1.GetChatsRequest) (*ch
 	return &chatv1.GetChatsResponse{
 		Chats:         chats,
 		NextPageToken: nextToken,
+	}, nil
+}
+
+func (s *Server) UpdateChat(ctx context.Context, req *chatv1.UpdateChatRequest) (*chatv1.UpdateChatResponse, error) {
+	id, err := identity.FromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity: %v", err)
+	}
+
+	if req.GetChatId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "chat_id is required")
+	}
+	threadID, err := parseUUID(req.GetChatId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "chat_id: %v", err)
+	}
+
+	params := store.UpdateChatParams{}
+	if req.GetStatus() != chatv1.ChatStatus_CHAT_STATUS_UNSPECIFIED {
+		statusValue := chatStatusToString(req.GetStatus())
+		params.Status = &statusValue
+	}
+	if req.Summary != nil {
+		summaryValue := req.GetSummary()
+		if summaryValue == "" {
+			params.ClearSummary = true
+		} else {
+			params.Summary = &summaryValue
+		}
+	}
+
+	updatedChat, err := s.store.UpdateChat(ctx, threadID, params)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	threadsByID, err := s.fetchThreads(ctx, id.IdentityID, []uuid.UUID{threadID})
+	if err != nil {
+		return nil, mapThreadsError(err)
+	}
+	thread, ok := threadsByID[threadID]
+	if !ok || !threadHasParticipant(thread, id.IdentityID) {
+		return nil, status.Error(codes.NotFound, "chat not found")
+	}
+
+	return &chatv1.UpdateChatResponse{
+		Chat: threadToChat(thread, updatedChat.OrganizationID.String(), stringToChatStatus(updatedChat.Status), updatedChat.Summary),
 	}, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,15 +78,15 @@ func (s *Server) CreateChat(ctx context.Context, req *chatv1.CreateChatRequest) 
 	if err != nil {
 		log.Printf("chat: store thread %s for org %s failed (returning thread only): %v", threadID, organizationID, err)
 	}
-	status := chatv1.ChatStatus_CHAT_STATUS_OPEN
+	chatStatus := chatv1.ChatStatus_CHAT_STATUS_OPEN
 	var summary *string
 	if err == nil {
-		status = stringToChatStatus(storedChat.Status)
+		chatStatus = stringToChatStatus(storedChat.Status)
 		summary = storedChat.Summary
 	}
 
 	return &chatv1.CreateChatResponse{
-		Chat: threadToChat(resp.GetThread(), organizationID.String(), status, summary),
+		Chat: threadToChat(resp.GetThread(), organizationID.String(), chatStatus, summary),
 	}, nil
 }
 
@@ -192,11 +192,6 @@ func (s *Server) UpdateChat(ctx context.Context, req *chatv1.UpdateChatRequest) 
 		}
 	}
 
-	updatedChat, err := s.store.UpdateChat(ctx, threadID, params)
-	if err != nil {
-		return nil, toStatusError(err)
-	}
-
 	threadsByID, err := s.fetchThreads(ctx, id.IdentityID, []uuid.UUID{threadID})
 	if err != nil {
 		return nil, mapThreadsError(err)
@@ -204,6 +199,11 @@ func (s *Server) UpdateChat(ctx context.Context, req *chatv1.UpdateChatRequest) 
 	thread, ok := threadsByID[threadID]
 	if !ok || !threadHasParticipant(thread, id.IdentityID) {
 		return nil, status.Error(codes.NotFound, "chat not found")
+	}
+
+	updatedChat, err := s.store.UpdateChat(ctx, threadID, params)
+	if err != nil {
+		return nil, toStatusError(err)
 	}
 
 	return &chatv1.UpdateChatResponse{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -88,7 +88,9 @@ func (m *mockThreadsClient) AckMessages(ctx context.Context, req *threadsv1.AckM
 
 type mockStore struct {
 	createChatFunc func(ctx context.Context, threadID, organizationID uuid.UUID) (store.Chat, error)
-	listChatsFunc  func(ctx context.Context, organizationID uuid.UUID, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error)
+	getChatFunc    func(ctx context.Context, threadID uuid.UUID) (store.Chat, error)
+	updateChatFunc func(ctx context.Context, threadID uuid.UUID, params store.UpdateChatParams) (store.Chat, error)
+	listChatsFunc  func(ctx context.Context, organizationID uuid.UUID, filter store.ChatListFilter, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error)
 }
 
 func (m *mockStore) CreateChat(ctx context.Context, threadID, organizationID uuid.UUID) (store.Chat, error) {
@@ -98,11 +100,25 @@ func (m *mockStore) CreateChat(ctx context.Context, threadID, organizationID uui
 	return m.createChatFunc(ctx, threadID, organizationID)
 }
 
-func (m *mockStore) ListChats(ctx context.Context, organizationID uuid.UUID, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
+func (m *mockStore) GetChat(ctx context.Context, threadID uuid.UUID) (store.Chat, error) {
+	if m.getChatFunc == nil {
+		return store.Chat{}, unexpectedStoreCall("GetChat")
+	}
+	return m.getChatFunc(ctx, threadID)
+}
+
+func (m *mockStore) UpdateChat(ctx context.Context, threadID uuid.UUID, params store.UpdateChatParams) (store.Chat, error) {
+	if m.updateChatFunc == nil {
+		return store.Chat{}, unexpectedStoreCall("UpdateChat")
+	}
+	return m.updateChatFunc(ctx, threadID, params)
+}
+
+func (m *mockStore) ListChats(ctx context.Context, organizationID uuid.UUID, filter store.ChatListFilter, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
 	if m.listChatsFunc == nil {
 		return store.ChatListResult{}, unexpectedStoreCall("ListChats")
 	}
-	return m.listChatsFunc(ctx, organizationID, pageSize, cursor)
+	return m.listChatsFunc(ctx, organizationID, filter, pageSize, cursor)
 }
 
 func unexpectedCall(method string) error {
@@ -186,7 +202,7 @@ func TestCreateChatDeduplicatesParticipants(t *testing.T) {
 		createChatFunc: func(ctx context.Context, threadID, organizationID uuid.UUID) (store.Chat, error) {
 			storedThreadID = threadID
 			storedOrgID = organizationID
-			return store.Chat{ThreadID: threadID, OrganizationID: organizationID, CreatedAt: time.Now()}, nil
+			return store.Chat{ThreadID: threadID, OrganizationID: organizationID, CreatedAt: time.Now(), Status: "open"}, nil
 		},
 	}
 
@@ -207,6 +223,9 @@ func TestCreateChatDeduplicatesParticipants(t *testing.T) {
 	}
 	if resp.GetChat().GetOrganizationId() != orgID.String() {
 		t.Fatalf("expected organization id %q, got %q", orgID, resp.GetChat().GetOrganizationId())
+	}
+	if resp.GetChat().GetStatus() != chatv1.ChatStatus_CHAT_STATUS_OPEN {
+		t.Fatalf("expected status open, got %s", resp.GetChat().GetStatus())
 	}
 	if storedThreadID != threadID {
 		t.Fatalf("expected stored thread id %s, got %s", threadID, storedThreadID)
@@ -245,6 +264,9 @@ func TestCreateChatReturnsThreadWhenStoreFails(t *testing.T) {
 	if resp.GetChat().GetOrganizationId() != orgID.String() {
 		t.Fatalf("expected organization id %q, got %q", orgID, resp.GetChat().GetOrganizationId())
 	}
+	if resp.GetChat().GetStatus() != chatv1.ChatStatus_CHAT_STATUS_OPEN {
+		t.Fatalf("expected status open, got %s", resp.GetChat().GetStatus())
+	}
 	if storedThreadID != threadID {
 		t.Fatalf("expected stored thread id %s, got %s", threadID, storedThreadID)
 	}
@@ -272,19 +294,22 @@ func TestGetChatsUsesStoreAndThreads(t *testing.T) {
 	threadID1 := uuid.New()
 	threadID2 := uuid.New()
 	createdAt := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+	summary := "needs follow-up"
 
 	var gotOrgID uuid.UUID
 	var gotPageSize int32
 	var gotCursor *store.PageCursor
+	var gotFilter store.ChatListFilter
 	chatStore := &mockStore{
-		listChatsFunc: func(ctx context.Context, organizationID uuid.UUID, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
+		listChatsFunc: func(ctx context.Context, organizationID uuid.UUID, filter store.ChatListFilter, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
 			gotOrgID = organizationID
 			gotPageSize = pageSize
 			gotCursor = cursor
+			gotFilter = filter
 			return store.ChatListResult{
 				Chats: []store.Chat{
-					{ThreadID: threadID2, OrganizationID: orgID, CreatedAt: createdAt},
-					{ThreadID: threadID1, OrganizationID: orgID, CreatedAt: createdAt},
+					{ThreadID: threadID2, OrganizationID: orgID, CreatedAt: createdAt, Status: "open", Summary: &summary},
+					{ThreadID: threadID1, OrganizationID: orgID, CreatedAt: createdAt, Status: "closed"},
 				},
 				NextCursor: &store.PageCursor{AfterID: threadID1},
 			}, nil
@@ -339,6 +364,9 @@ func TestGetChatsUsesStoreAndThreads(t *testing.T) {
 	if gotCursor == nil || gotCursor.AfterID != cursorID {
 		t.Fatalf("expected cursor %s, got %#v", cursorID, gotCursor)
 	}
+	if gotFilter.Status != nil {
+		t.Fatalf("expected nil status filter, got %v", *gotFilter.Status)
+	}
 	if resp.GetNextPageToken() != store.EncodePageToken(threadID1) {
 		t.Fatalf("expected next page token %q, got %q", store.EncodePageToken(threadID1), resp.GetNextPageToken())
 	}
@@ -350,6 +378,58 @@ func TestGetChatsUsesStoreAndThreads(t *testing.T) {
 	}
 	if resp.GetChats()[0].GetOrganizationId() != orgID.String() {
 		t.Fatalf("expected org id %q, got %q", orgID, resp.GetChats()[0].GetOrganizationId())
+	}
+	if resp.GetChats()[0].GetStatus() != chatv1.ChatStatus_CHAT_STATUS_OPEN {
+		t.Fatalf("expected status open, got %s", resp.GetChats()[0].GetStatus())
+	}
+	if resp.GetChats()[1].GetStatus() != chatv1.ChatStatus_CHAT_STATUS_CLOSED {
+		t.Fatalf("expected status closed, got %s", resp.GetChats()[1].GetStatus())
+	}
+	if resp.GetChats()[0].GetSummary() != summary {
+		t.Fatalf("expected summary %q, got %q", summary, resp.GetChats()[0].GetSummary())
+	}
+}
+
+func TestGetChatsAppliesStatusFilter(t *testing.T) {
+	ctx := contextWithIdentity("user-1")
+	orgID := uuid.New()
+	threadID := uuid.New()
+	createdAt := time.Date(2024, 5, 8, 9, 10, 11, 0, time.UTC)
+
+	var gotFilter store.ChatListFilter
+	chatStore := &mockStore{
+		listChatsFunc: func(ctx context.Context, organizationID uuid.UUID, filter store.ChatListFilter, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
+			gotFilter = filter
+			return store.ChatListResult{
+				Chats: []store.Chat{{ThreadID: threadID, OrganizationID: orgID, CreatedAt: createdAt, Status: "closed"}},
+			}, nil
+		},
+	}
+
+	threads := &mockThreadsClient{
+		getThreadsFunc: func(ctx context.Context, req *threadsv1.GetThreadsRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+			return &threadsv1.GetThreadsResponse{
+				Threads: []*threadsv1.Thread{
+					{
+						Id: threadID.String(),
+						Participants: []*threadsv1.Participant{
+							{Id: "user-1", JoinedAt: timestamppb.New(createdAt)},
+						},
+						CreatedAt: timestamppb.New(createdAt),
+						UpdatedAt: timestamppb.New(createdAt),
+					},
+				},
+			}, nil
+		},
+	}
+
+	srv := New(threads, chatStore)
+	_, err := srv.GetChats(ctx, &chatv1.GetChatsRequest{OrganizationId: orgID.String(), Status: chatv1.ChatStatus_CHAT_STATUS_CLOSED})
+	if err != nil {
+		t.Fatalf("GetChats returned error: %v", err)
+	}
+	if gotFilter.Status == nil || *gotFilter.Status != "closed" {
+		t.Fatalf("expected status filter closed, got %#v", gotFilter.Status)
 	}
 }
 
@@ -363,10 +443,13 @@ func TestGetChatsFillsPageAfterFiltering(t *testing.T) {
 
 	listCalls := 0
 	chatStore := &mockStore{
-		listChatsFunc: func(ctx context.Context, organizationID uuid.UUID, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
+		listChatsFunc: func(ctx context.Context, organizationID uuid.UUID, filter store.ChatListFilter, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
 			listCalls++
 			switch listCalls {
 			case 1:
+				if filter.Status != nil {
+					return store.ChatListResult{}, fmt.Errorf("expected nil status filter")
+				}
 				if cursor != nil {
 					return store.ChatListResult{}, fmt.Errorf("expected nil cursor")
 				}
@@ -375,12 +458,15 @@ func TestGetChatsFillsPageAfterFiltering(t *testing.T) {
 				}
 				return store.ChatListResult{
 					Chats: []store.Chat{
-						{ThreadID: threadID1, OrganizationID: orgID, CreatedAt: createdAt},
-						{ThreadID: threadID2, OrganizationID: orgID, CreatedAt: createdAt},
+						{ThreadID: threadID1, OrganizationID: orgID, CreatedAt: createdAt, Status: "open"},
+						{ThreadID: threadID2, OrganizationID: orgID, CreatedAt: createdAt, Status: "open"},
 					},
 					NextCursor: &store.PageCursor{AfterID: threadID2},
 				}, nil
 			case 2:
+				if filter.Status != nil {
+					return store.ChatListResult{}, fmt.Errorf("expected nil status filter")
+				}
 				if cursor == nil || cursor.AfterID != threadID2 {
 					return store.ChatListResult{}, fmt.Errorf("expected cursor %s, got %#v", threadID2, cursor)
 				}
@@ -388,7 +474,7 @@ func TestGetChatsFillsPageAfterFiltering(t *testing.T) {
 					return store.ChatListResult{}, fmt.Errorf("expected page size 1, got %d", pageSize)
 				}
 				return store.ChatListResult{
-					Chats:      []store.Chat{{ThreadID: threadID3, OrganizationID: orgID, CreatedAt: createdAt}},
+					Chats:      []store.Chat{{ThreadID: threadID3, OrganizationID: orgID, CreatedAt: createdAt, Status: "open"}},
 					NextCursor: &store.PageCursor{AfterID: threadID3},
 				}, nil
 			default:
@@ -468,9 +554,12 @@ func TestGetChatsFiltersNonParticipantThreads(t *testing.T) {
 	createdAt := time.Date(2024, 6, 7, 8, 9, 10, 0, time.UTC)
 
 	chatStore := &mockStore{
-		listChatsFunc: func(ctx context.Context, organizationID uuid.UUID, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
+		listChatsFunc: func(ctx context.Context, organizationID uuid.UUID, filter store.ChatListFilter, pageSize int32, cursor *store.PageCursor) (store.ChatListResult, error) {
+			if filter.Status != nil {
+				return store.ChatListResult{}, fmt.Errorf("expected nil status filter")
+			}
 			return store.ChatListResult{
-				Chats: []store.Chat{{ThreadID: threadID, OrganizationID: orgID, CreatedAt: createdAt}},
+				Chats: []store.Chat{{ThreadID: threadID, OrganizationID: orgID, CreatedAt: createdAt, Status: "open"}},
 			}, nil
 		},
 	}
@@ -500,6 +589,136 @@ func TestGetChatsFiltersNonParticipantThreads(t *testing.T) {
 	if len(resp.GetChats()) != 0 {
 		t.Fatalf("expected no chats, got %d", len(resp.GetChats()))
 	}
+}
+
+func TestUpdateChatRequiresIdentity(t *testing.T) {
+	srv := New(&mockThreadsClient{}, &mockStore{})
+	_, err := srv.UpdateChat(context.Background(), &chatv1.UpdateChatRequest{ChatId: uuid.NewString()})
+	requireStatusCode(t, err, codes.Unauthenticated)
+}
+
+func TestUpdateChatRejectsInvalidChatID(t *testing.T) {
+	srv := New(&mockThreadsClient{}, &mockStore{})
+	_, err := srv.UpdateChat(contextWithIdentity("user-1"), &chatv1.UpdateChatRequest{ChatId: "not-a-uuid"})
+	requireStatusCode(t, err, codes.InvalidArgument)
+}
+
+func TestUpdateChatUpdatesStatus(t *testing.T) {
+	ctx := contextWithIdentity("user-1")
+	threadID := uuid.New()
+	orgID := uuid.New()
+	createdAt := time.Date(2024, 7, 1, 2, 3, 4, 0, time.UTC)
+
+	var gotParams store.UpdateChatParams
+	chatStore := &mockStore{
+		updateChatFunc: func(ctx context.Context, chatID uuid.UUID, params store.UpdateChatParams) (store.Chat, error) {
+			gotParams = params
+			if chatID != threadID {
+				return store.Chat{}, fmt.Errorf("unexpected chat id %s", chatID)
+			}
+			return store.Chat{ThreadID: chatID, OrganizationID: orgID, CreatedAt: createdAt, Status: "closed"}, nil
+		},
+	}
+
+	threads := &mockThreadsClient{
+		getThreadsFunc: func(ctx context.Context, req *threadsv1.GetThreadsRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+			if req.GetParticipantId() != "user-1" {
+				return nil, status.Errorf(codes.InvalidArgument, "unexpected participant %q", req.GetParticipantId())
+			}
+			return &threadsv1.GetThreadsResponse{
+				Threads: []*threadsv1.Thread{
+					{
+						Id: threadID.String(),
+						Participants: []*threadsv1.Participant{
+							{Id: "user-1", JoinedAt: timestamppb.New(createdAt)},
+						},
+						CreatedAt: timestamppb.New(createdAt),
+						UpdatedAt: timestamppb.New(createdAt),
+					},
+				},
+			}, nil
+		},
+	}
+
+	srv := New(threads, chatStore)
+	resp, err := srv.UpdateChat(ctx, &chatv1.UpdateChatRequest{ChatId: threadID.String(), Status: chatv1.ChatStatus_CHAT_STATUS_CLOSED})
+	if err != nil {
+		t.Fatalf("UpdateChat returned error: %v", err)
+	}
+	if gotParams.Status == nil || *gotParams.Status != "closed" {
+		t.Fatalf("expected status closed, got %#v", gotParams.Status)
+	}
+	if gotParams.Summary != nil || gotParams.ClearSummary {
+		t.Fatalf("expected summary untouched, got %#v", gotParams)
+	}
+	if resp.GetChat().GetStatus() != chatv1.ChatStatus_CHAT_STATUS_CLOSED {
+		t.Fatalf("expected status closed, got %s", resp.GetChat().GetStatus())
+	}
+}
+
+func TestUpdateChatUpdatesSummary(t *testing.T) {
+	ctx := contextWithIdentity("user-1")
+	threadID := uuid.New()
+	orgID := uuid.New()
+	createdAt := time.Date(2024, 7, 2, 3, 4, 5, 0, time.UTC)
+	summary := "triage summary"
+
+	var gotParams store.UpdateChatParams
+	chatStore := &mockStore{
+		updateChatFunc: func(ctx context.Context, chatID uuid.UUID, params store.UpdateChatParams) (store.Chat, error) {
+			gotParams = params
+			if chatID != threadID {
+				return store.Chat{}, fmt.Errorf("unexpected chat id %s", chatID)
+			}
+			return store.Chat{ThreadID: chatID, OrganizationID: orgID, CreatedAt: createdAt, Status: "open", Summary: &summary}, nil
+		},
+	}
+
+	threads := &mockThreadsClient{
+		getThreadsFunc: func(ctx context.Context, req *threadsv1.GetThreadsRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+			return &threadsv1.GetThreadsResponse{
+				Threads: []*threadsv1.Thread{
+					{
+						Id: threadID.String(),
+						Participants: []*threadsv1.Participant{
+							{Id: "user-1", JoinedAt: timestamppb.New(createdAt)},
+						},
+						CreatedAt: timestamppb.New(createdAt),
+						UpdatedAt: timestamppb.New(createdAt),
+					},
+				},
+			}, nil
+		},
+	}
+
+	srv := New(threads, chatStore)
+	resp, err := srv.UpdateChat(ctx, &chatv1.UpdateChatRequest{ChatId: threadID.String(), Summary: &summary})
+	if err != nil {
+		t.Fatalf("UpdateChat returned error: %v", err)
+	}
+	if gotParams.Summary == nil || *gotParams.Summary != summary {
+		t.Fatalf("expected summary %q, got %#v", summary, gotParams.Summary)
+	}
+	if gotParams.ClearSummary {
+		t.Fatalf("expected summary to be set, got clear")
+	}
+	if resp.GetChat().GetSummary() != summary {
+		t.Fatalf("expected summary %q, got %q", summary, resp.GetChat().GetSummary())
+	}
+}
+
+func TestUpdateChatNotFound(t *testing.T) {
+	ctx := contextWithIdentity("user-1")
+	threadID := uuid.New()
+	chatStore := &mockStore{
+		updateChatFunc: func(ctx context.Context, chatID uuid.UUID, params store.UpdateChatParams) (store.Chat, error) {
+			return store.Chat{}, store.NotFound("chat")
+		},
+	}
+
+	srv := New(&mockThreadsClient{}, chatStore)
+	_, err := srv.UpdateChat(ctx, &chatv1.UpdateChatRequest{ChatId: threadID.String(), Status: chatv1.ChatStatus_CHAT_STATUS_OPEN})
+	requireStatusCode(t, err, codes.NotFound)
 }
 
 func TestGetMessagesAggregatesUnread(t *testing.T) {
@@ -683,8 +902,9 @@ func TestThreadToChat(t *testing.T) {
 		CreatedAt: timestamppb.New(createdAt),
 		UpdatedAt: timestamppb.New(updatedAt),
 	}
+	summary := "ready"
 
-	chat := threadToChat(thread, "org-1")
+	chat := threadToChat(thread, "org-1", chatv1.ChatStatus_CHAT_STATUS_OPEN, &summary)
 	if chat.GetId() != "thread-1" {
 		t.Fatalf("expected chat id thread-1, got %q", chat.GetId())
 	}
@@ -696,6 +916,12 @@ func TestThreadToChat(t *testing.T) {
 	}
 	if chat.GetOrganizationId() != "org-1" {
 		t.Fatalf("expected organization id org-1, got %q", chat.GetOrganizationId())
+	}
+	if chat.GetStatus() != chatv1.ChatStatus_CHAT_STATUS_OPEN {
+		t.Fatalf("expected status open, got %s", chat.GetStatus())
+	}
+	if chat.GetSummary() != summary {
+		t.Fatalf("expected summary %q, got %q", summary, chat.GetSummary())
 	}
 	requireTimestamp(t, chat.GetParticipants()[0].GetJoinedAt(), joinedAt)
 	requireTimestamp(t, chat.GetCreatedAt(), createdAt)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -710,13 +710,30 @@ func TestUpdateChatUpdatesSummary(t *testing.T) {
 func TestUpdateChatNotFound(t *testing.T) {
 	ctx := contextWithIdentity("user-1")
 	threadID := uuid.New()
+	createdAt := time.Date(2024, 7, 3, 4, 5, 6, 0, time.UTC)
 	chatStore := &mockStore{
 		updateChatFunc: func(ctx context.Context, chatID uuid.UUID, params store.UpdateChatParams) (store.Chat, error) {
 			return store.Chat{}, store.NotFound("chat")
 		},
 	}
+	threads := &mockThreadsClient{
+		getThreadsFunc: func(ctx context.Context, req *threadsv1.GetThreadsRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+			return &threadsv1.GetThreadsResponse{
+				Threads: []*threadsv1.Thread{
+					{
+						Id: threadID.String(),
+						Participants: []*threadsv1.Participant{
+							{Id: "user-1", JoinedAt: timestamppb.New(createdAt)},
+						},
+						CreatedAt: timestamppb.New(createdAt),
+						UpdatedAt: timestamppb.New(createdAt),
+					},
+				},
+			}, nil
+		},
+	}
 
-	srv := New(&mockThreadsClient{}, chatStore)
+	srv := New(threads, chatStore)
 	_, err := srv.UpdateChat(ctx, &chatv1.UpdateChatRequest{ChatId: threadID.String(), Status: chatv1.ChatStatus_CHAT_STATUS_OPEN})
 	requireStatusCode(t, err, codes.NotFound)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -13,7 +14,7 @@ import (
 )
 
 const (
-	chatColumns       = "thread_id, organization_id, created_at"
+	chatColumns       = "thread_id, organization_id, created_at, status, summary"
 	pgUniqueViolation = "23505"
 )
 
@@ -27,7 +28,7 @@ func New(pool *pgxpool.Pool) *Store {
 
 func scanChat(row pgx.Row) (Chat, error) {
 	var chat Chat
-	if err := row.Scan(&chat.ThreadID, &chat.OrganizationID, &chat.CreatedAt); err != nil {
+	if err := row.Scan(&chat.ThreadID, &chat.OrganizationID, &chat.CreatedAt, &chat.Status, &chat.Summary); err != nil {
 		return Chat{}, err
 	}
 	return chat, nil
@@ -52,14 +53,71 @@ func (s *Store) CreateChat(ctx context.Context, threadID, organizationID uuid.UU
 	return chat, nil
 }
 
-func (s *Store) ListChats(ctx context.Context, organizationID uuid.UUID, pageSize int32, cursor *PageCursor) (ChatListResult, error) {
+func (s *Store) GetChat(ctx context.Context, threadID uuid.UUID) (Chat, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf("SELECT %s FROM chats WHERE thread_id = $1", chatColumns),
+		threadID,
+	)
+	chat, err := scanChat(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Chat{}, NotFound("chat")
+		}
+		return Chat{}, err
+	}
+	return chat, nil
+}
+
+func (s *Store) UpdateChat(ctx context.Context, threadID uuid.UUID, params UpdateChatParams) (Chat, error) {
+	setClauses := make([]string, 0, 2)
+	args := make([]any, 0, 3)
+
+	if params.Status != nil {
+		args = append(args, *params.Status)
+		setClauses = append(setClauses, fmt.Sprintf("status = $%d", len(args)))
+	}
+	if params.ClearSummary {
+		setClauses = append(setClauses, "summary = NULL")
+	} else if params.Summary != nil {
+		args = append(args, *params.Summary)
+		setClauses = append(setClauses, fmt.Sprintf("summary = $%d", len(args)))
+	}
+
+	if len(setClauses) == 0 {
+		return s.GetChat(ctx, threadID)
+	}
+
+	args = append(args, threadID)
+	query := fmt.Sprintf("UPDATE chats SET %s WHERE thread_id = $%d RETURNING %s", strings.Join(setClauses, ", "), len(args), chatColumns)
+	row := s.pool.QueryRow(ctx, query, args...)
+	chat, err := scanChat(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Chat{}, NotFound("chat")
+		}
+		return Chat{}, err
+	}
+	return chat, nil
+}
+
+func (s *Store) ListChats(ctx context.Context, organizationID uuid.UUID, filter ChatListFilter, pageSize int32, cursor *PageCursor) (ChatListResult, error) {
 	limit := NormalizePageSize(pageSize)
 	query := fmt.Sprintf("SELECT %s FROM chats WHERE organization_id = $1", chatColumns)
 	args := []any{organizationID}
+	if filter.Status != nil {
+		args = append(args, *filter.Status)
+		query += fmt.Sprintf(" AND status = $%d", len(args))
+	}
 
 	var cursorCreatedAt time.Time
 	if cursor != nil {
-		if err := s.pool.QueryRow(ctx, `SELECT created_at FROM chats WHERE thread_id = $1 AND organization_id = $2`, cursor.AfterID, organizationID).Scan(&cursorCreatedAt); err != nil {
+		cursorQuery := `SELECT created_at FROM chats WHERE thread_id = $1 AND organization_id = $2`
+		cursorArgs := []any{cursor.AfterID, organizationID}
+		if filter.Status != nil {
+			cursorArgs = append(cursorArgs, *filter.Status)
+			cursorQuery += fmt.Sprintf(" AND status = $%d", len(cursorArgs))
+		}
+		if err := s.pool.QueryRow(ctx, cursorQuery, cursorArgs...).Scan(&cursorCreatedAt); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return ChatListResult{}, InvalidPageToken(fmt.Errorf("cursor not found"))
 			}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -10,6 +10,8 @@ type Chat struct {
 	ThreadID       uuid.UUID
 	OrganizationID uuid.UUID
 	CreatedAt      time.Time
+	Status         string
+	Summary        *string
 }
 
 type PageCursor struct {
@@ -19,4 +21,14 @@ type PageCursor struct {
 type ChatListResult struct {
 	Chats      []Chat
 	NextCursor *PageCursor
+}
+
+type UpdateChatParams struct {
+	Status       *string
+	Summary      *string
+	ClearSummary bool
+}
+
+type ChatListFilter struct {
+	Status *string
 }

--- a/migrations/0002_add_status_and_summary.sql
+++ b/migrations/0002_add_status_and_summary.sql
@@ -1,0 +1,5 @@
+ALTER TABLE chats
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'open',
+    ADD COLUMN summary TEXT;
+
+CREATE INDEX chats_org_status_created_idx ON chats (organization_id, status, created_at DESC, thread_id DESC);


### PR DESCRIPTION
## Summary
- add status/summary columns and index with store support for updates and filtering
- implement UpdateChat handling plus status/summary mapping in server responses
- extend server tests for status filters and chat updates

## Testing
- CHAT_ADDRESS=127.0.0.1:50051 go test ./...
- go vet ./...

Closes #22